### PR TITLE
fix citation first name bug in FP#681136

### DIFF
--- a/src/Publication.php
+++ b/src/Publication.php
@@ -608,9 +608,11 @@ class Publication
         $publication->editor = array();
 
         foreach ($this->get_authors() as $author) {
+            $firstname = ($csl !== 'chicago-author-date') ? substr($author->get_firstname(), 0, 1) : $author->get_firstname();
+            $lastname = $author->get_lastname();
             $record = array(
-                "given" => $this->encode_for_citeproc($author->get_firstname()),
-                "family" => $this->encode_for_citeproc($author->get_lastname())
+                "given" => $this->encode_for_citeproc($firstname),
+                "family" => $this->encode_for_citeproc($lastname)
             );
             $publication->author[] = (object)$record;
         }


### PR DESCRIPTION
Pass only first character of first name to citeproc when it doesn't need the rest. It seems not to cope very well when trying to shorten first names with special characters.
